### PR TITLE
Supporting Storage Read/Write IO/Octets MIB information

### DIFF
--- a/globalHandler.h
+++ b/globalHandler.h
@@ -60,9 +60,13 @@ typedef struct _vm_storage {
     /* vmStorageAllocatedSize */
     long allocsize;
     /* vmReadIOs */
-    long readios;
+    uint64_t readios;
     /* vmWriteIOs */
-    long writeios;
+    uint64_t writeios;
+    /* vmReadOctets */
+    uint64_t readoctets;
+    /* vmWriteOctets */
+    uint64_t writeoctets;
 } vm_storage_t;
 
 typedef struct _vm_interface {
@@ -204,6 +208,8 @@ extern "C" {
     long gh_getVstorageTable_vmStorageAllocatedSize(long, long);
     uint64_t gh_getVstorageTable_vmStorageReadIOs(long, long);
     uint64_t gh_getVstorageTable_vmStorageWriteIOs(long, long);
+    uint64_t gh_getVstorageTable_vmStorageReadOctets(long, long);
+    uint64_t gh_getVstorageTable_vmStorageWriteOctets(long, long);
 
     /* vmNetworkTable */
     long gh_getVifTable_vmNetworkIfIndex(long, long);

--- a/vmStorageTable.c
+++ b/vmStorageTable.c
@@ -43,7 +43,7 @@ initialize_table_vmStorageTable(void)
                            ASN_INTEGER,  /* index: vmStorageIndex */
                            0);
     table_info->min_column = COLUMN_VMSTORAGEVMINDEX;
-    table_info->max_column = COLUMN_VMSTORAGEWRITEIOS;
+    table_info->max_column = COLUMN_VMSTORAGEWRITEOCTETS;
 
     iinfo = SNMP_MALLOC_TYPEDEF( netsnmp_iterator_info );
     iinfo->get_first_data_point = vmStorageTable_get_first_data_point;
@@ -191,6 +191,8 @@ vmStorageTable_handler(
     long vmStorageAllocatedSize;
     U64 vmStorageReadIOs;
     U64 vmStorageWriteIOs;
+    U64 vmStorageReadOctets;
+    U64 vmStorageWriteOctets;
     uint64_t val64;
     int ret;
 
@@ -353,7 +355,7 @@ vmStorageTable_handler(
                                               SNMP_NOSUCHINSTANCE);
                     continue;
                 }
-                val64 = gh_getVstorageTable_vmStorageReadIOs(
+                val64 = gh_getVstorageTable_vmStorageWriteIOs(
                     table_entry->vmStorageVmIndex, table_entry->vmStorageIndex);
                 vmStorageReadIOs.high = (val64 >> 32) & 0xffffffff;
                 vmStorageReadIOs.low = val64 & 0xffffffff;
@@ -376,6 +378,36 @@ vmStorageTable_handler(
                 snmp_set_var_typed_value( request->requestvb, ASN_COUNTER64,
                                           &vmStorageWriteIOs,
                                           sizeof(vmStorageWriteIOs));
+                break;
+            case COLUMN_VMSTORAGEREADOCTETS:
+                if ( !table_entry ) {
+                    netsnmp_set_request_error(reqinfo, request,
+                                              SNMP_NOSUCHINSTANCE);
+                    continue;
+                }
+                val64 = gh_getVstorageTable_vmStorageReadOctets(
+                    table_entry->vmStorageVmIndex, table_entry->vmStorageIndex);
+                vmStorageReadOctets.high = (val64 >> 32) & 0xffffffff;
+                vmStorageReadOctets.low = val64 & 0xffffffff;
+
+                snmp_set_var_typed_value( request->requestvb, ASN_COUNTER64,
+                                          &vmStorageReadOctets,
+                                          sizeof(vmStorageReadOctets));
+                break;
+            case COLUMN_VMSTORAGEWRITEOCTETS:
+                if ( !table_entry ) {
+                    netsnmp_set_request_error(reqinfo, request,
+                                              SNMP_NOSUCHINSTANCE);
+                    continue;
+                }
+                val64 = gh_getVstorageTable_vmStorageWriteOctets(
+                    table_entry->vmStorageVmIndex, table_entry->vmStorageIndex);
+                vmStorageWriteOctets.high = (val64 >> 32) & 0xffffffff;
+                vmStorageWriteOctets.low = val64 & 0xffffffff;
+
+                snmp_set_var_typed_value( request->requestvb, ASN_COUNTER64,
+                                          &vmStorageWriteOctets,
+                                          sizeof(vmStorageWriteOctets));
                 break;
             default:
                 netsnmp_set_request_error(reqinfo, request,

--- a/vmStorageTable.c
+++ b/vmStorageTable.c
@@ -355,7 +355,7 @@ vmStorageTable_handler(
                                               SNMP_NOSUCHINSTANCE);
                     continue;
                 }
-                val64 = gh_getVstorageTable_vmStorageWriteIOs(
+                val64 = gh_getVstorageTable_vmStorageReadIOs(
                     table_entry->vmStorageVmIndex, table_entry->vmStorageIndex);
                 vmStorageReadIOs.high = (val64 >> 32) & 0xffffffff;
                 vmStorageReadIOs.low = val64 & 0xffffffff;

--- a/vmStorageTable.c
+++ b/vmStorageTable.c
@@ -368,7 +368,7 @@ vmStorageTable_handler(
                                               SNMP_NOSUCHINSTANCE);
                     continue;
                 }
-                val64 = gh_getVstorageTable_vmStorageReadIOs(
+                val64 = gh_getVstorageTable_vmStorageWriteIOs(
                     table_entry->vmStorageVmIndex, table_entry->vmStorageIndex);
                 vmStorageWriteIOs.high = (val64 >> 32) & 0xffffffff;
                 vmStorageWriteIOs.low = val64 & 0xffffffff;

--- a/vmStorageTable.h
+++ b/vmStorageTable.h
@@ -30,6 +30,8 @@ void vmStorageTable_removeEntryByIndex(long, long);
 #define COLUMN_VMSTORAGEALLOCATEDSIZE           12
 #define COLUMN_VMSTORAGEREADIOS                 13
 #define COLUMN_VMSTORAGEWRITEIOS                14
+#define COLUMN_VMSTORAGEREADOCTETS              15
+#define COLUMN_VMSTORAGEWRITEOCTETS             16
 
 
 #endif /* VMSTORAGETABLE_H */


### PR DESCRIPTION
Added a support of StorageRead/Write IO/Octets using virDomainBlockStat() call.
